### PR TITLE
feat: add role-based recipient schema for WhatsApp notifications

### DIFF
--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification/whatsapp_notification.json
@@ -25,6 +25,8 @@
   "attach_from_field",
   "file_name",
   "whatsapp_account",
+  "recipients_section",
+  "recipients",
   "section_break_11",
   "condition",
   "column_break_12",
@@ -109,8 +111,8 @@
    "description": "Mobile number field",
    "fieldname": "field_name",
    "fieldtype": "Data",
-   "label": "Field Name",
-   "mandatory_depends_on": "eval:['DocType Event'].includes(doc.notification_type)"
+   "label": "Field Name (Phone Number)",
+   "mandatory_depends_on": "eval:['DocType Event'].includes(doc.notification_type) && !(doc.recipients && doc.recipients.length)"
   },
   {
    "fieldname": "column_break_12",
@@ -225,11 +227,23 @@
    "fieldtype": "Link",
    "label": "WhatsApp Account",
    "options": "WhatsApp Account"
+  },
+  {
+   "fieldname": "recipients_section",
+   "fieldtype": "Section Break",
+   "label": "Recipients by Role"
+  },
+  {
+   "description": "Sends to every enabled user holding these roles. Combines with Field Name: set either, or both.",
+   "fieldname": "recipients",
+   "fieldtype": "Table",
+   "label": "Recipients",
+   "options": "WhatsApp Notification Recipient"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-03-27 18:34:22.530859",
+ "modified": "2026-09-02 14:46:33.821117",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Notification",

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_recipient/whatsapp_notification_recipient.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_recipient/whatsapp_notification_recipient.json
@@ -1,0 +1,44 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2026-09-02 14:41:13.697261",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "receiver_by_role",
+  "condition"
+ ],
+ "fields": [
+  {
+   "fieldname": "receiver_by_role",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "Role",
+   "reqd": 1
+  },
+  {
+   "description": "Optional Python expression evaluated per row, e.g. doc.parent == \"Holiday List-Kolkata-WB4\". Leave blank to always include this role. Ignored for Scheduler Event notifications, which have no document.",
+   "fieldname": "condition",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Condition"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-09-02 14:46:33.821117",
+ "modified_by": "Administrator",
+ "module": "Frappe Whatsapp",
+ "name": "WhatsApp Notification Recipient",
+ "owner": "Administrator",
+ "permissions": [],
+ "row_format": "Dynamic",
+ "rows_threshold_for_grid_search": 20,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_recipient/whatsapp_notification_recipient.py
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_notification_recipient/whatsapp_notification_recipient.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026, Shridhar Patil and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class WhatsAppNotificationRecipient(Document):
+	pass

--- a/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
+++ b/frappe_whatsapp/frappe_whatsapp/doctype/whatsapp_settings/whatsapp_settings.json
@@ -8,7 +8,10 @@
  "field_order": [
   "default_incoming_account",
   "column_break_xsuw",
-  "default_outgoing_account"
+  "default_outgoing_account",
+  "role_recipient_section",
+  "role_phone_source",
+  "default_country_code"
  ],
  "fields": [
   {
@@ -26,13 +29,33 @@
   {
    "fieldname": "column_break_skjo",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "role_recipient_section",
+   "fieldtype": "Section Break",
+   "label": "Role Recipient Settings"
+  },
+  {
+   "default": "User Mobile No, then Employee",
+   "description": "How to resolve a phone number for users matched by role.",
+   "fieldname": "role_phone_source",
+   "fieldtype": "Select",
+   "label": "Phone Number Source",
+   "options": "User Mobile No, then Employee\nEmployee, then User Mobile No\nUser Mobile No\nEmployee Cell Number"
+  },
+  {
+   "default": "91",
+   "description": "Prepended to numbers stored without a country code. User.mobile_no is usually 10 digits in India; WhatsApp requires the country code.",
+   "fieldname": "default_country_code",
+   "fieldtype": "Data",
+   "label": "Default Country Code"
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-12-01 13:22:14.262545",
+ "modified": "2026-09-02 14:46:33.821117",
  "modified_by": "Administrator",
  "module": "Frappe Whatsapp",
  "name": "WhatsApp Settings",


### PR DESCRIPTION
Adds the schema for notifying every user holding a given Role, mirroring core Frappe's Notification Recipient child table for the Email channel. Controller logic follows in a later commit; this change is purely additive and does not alter existing behaviour.

- New child doctype "WhatsApp Notification Recipient" with receiver_by_role (Link -> Role, mandatory) and an optional per-row condition expression.
- New "Recipients by Role" section on WhatsApp Notification holding a `recipients` table. Placed after whatsapp_account so the preceding section closes cleanly and the existing column layout is preserved.
- field_name is no longer mandatory when roles are set, so a roles-only notification can be saved. The matching server-side check in validate() is relaxed in the follow-up commit.
- New WhatsApp Settings fields: role_phone_source (how to resolve a user's number) and default_country_code (User.mobile_no is typically stored without one, which Meta rejects).

Requires `bench migrate` to apply.